### PR TITLE
deploy to azure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "gatsby-theme-parliament-platform",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
PATH_PREFIX is cc-developer-platform pages
This site uses several mappings, so if the mapping source has sub-folders, we will need to tweak Fastly to do a re-mapping.

